### PR TITLE
Fix handling of Payload-Files-Allowed /* patterns to include nested directory contents

### DIFF
--- a/bagit_utils/validator.py
+++ b/bagit_utils/validator.py
@@ -1,6 +1,6 @@
 """BagIt-profile validator definition."""
 
-from typing import Iterable, Mapping, Optional
+from typing import Mapping, Optional
 from urllib.request import urlopen
 from pathlib import Path
 from json import load, loads
@@ -1187,81 +1187,35 @@ class BagValidator:
     def validate_payload_files_allowed(
         cls, bag: Bag, profile: Mapping
     ) -> ValidationReport:
-        """Validate 'Payload-Files-Allowed'-section of `profile` in `bag`.
-
-        - If 'Payload-Files-Allowed' is missing/None -> valid (no restrictions).
-        - Each entry is a path (relative to bag base) or a glob pattern where
-          '*' matches zero or more characters (glob(7)-style).
-        - Entries ending with '/*' are treated as "this directory and everything
-          beneath it" (recursive).
-        """
+        """Validate 'Payload-Files-Allowed'-section of `profile` in `bag`."""
         result = ValidationReport(True)
-
-        allowed_patterns = profile.get("Payload-Files-Allowed")
-        if allowed_patterns is None:
+        if profile.get("Payload-Files-Allowed") is None:
             return result
 
-        allowed_matchers = cls._compile_payload_allowed_matchers(
-            allowed_patterns
-        )
-
-        for file in (
-            f for f in bag.path.glob("data/**/*") if f.is_file()
-        ):
-            rel_posix = file.relative_to(bag.path).as_posix()
-
-            if not any(m(rel_posix) for m in allowed_matchers):
+        for file in [f for f in bag.path.glob("data/**/*") if f.is_file()]:
+            match = False
+            for p in profile["Payload-Files-Allowed"]:
+                # regular pattern matching
+                if file.relative_to(bag.path).match(p):
+                    match = True
+                    break
+                # capture sub-directories like data/a/b/c if pattern is given
+                # in the format data/a/*
+                if p.endswith("/*"):
+                    if Path(p[:-2]) in file.relative_to(bag.path).parents:
+                        match = True
+                        break
+            if not match:
                 result.valid = False
                 result.issues.append(
                     Issue(
                         "error",
-                        (
-                            f"Payload file '{rel_posix}' in Bag at "
-                            f"'{bag.path}' is not allowed."
-                        ),
+                        f"Payload file '{Path(file).relative_to(bag.path)}' in"
+                        + f" Bag at '{bag.path}' is not allowed.",
                         "Payload-Files-Allowed",
                     )
                 )
-
         return result
-
-    @staticmethod
-    def _compile_payload_allowed_matchers(
-        patterns: Iterable[str],
-    ):
-        """Create match functions for each allowed pattern.
-
-        - pattern ending in '/*' allows the directory itself and anything below
-          it (recursive).
-        - otherwise use pathlib.Path.match for glob(ish) matching on the full
-          relative path.
-        """
-        matchers = []
-
-        for pattern in patterns:
-            if pattern.endswith("/*"):
-                dir_pattern = pattern[:-2].rstrip("/")
-
-                def matches(
-                        rel_posix: str,
-                        dir_pattern: str = dir_pattern,
-                        ) -> bool:
-                    rel_path = Path(rel_posix)
-                    return any(
-                        parent.match(dir_pattern)
-                        for parent in rel_path.parents
-                        )
-                matchers.append(matches)
-            else:
-                def matches(
-                    rel_posix: str,
-                    pattern=pattern,
-                ) -> bool:
-                    return Path(rel_posix).match(pattern)
-
-                matchers.append(matches)
-
-        return matchers
 
     @classmethod
     def custom_validation_hook(

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -583,18 +583,15 @@ def test_bag_validator_payload_files_required(src, dst, profile, callback, ok):
 @pytest.mark.parametrize(
     ("profile", "callback", "ok"),
     [
+        # Empty allowlist: any payload file is forbidden
         (
             {"Payload-Files-Allowed": []},
-            lambda bag: None,
+            lambda bag: (bag.path / "data" / "payload.txt").touch(),
             False,
         ),
+        # Allow everything under data/ (recursive directory permission)
         (
             {"Payload-Files-Allowed": ["data/*"]},
-            lambda bag: None,
-            True,
-        ),
-        (
-            {"Payload-Files-Allowed": ["**/*"]},
             lambda bag: [
                 (bag.path / "data" / "payload1.txt").touch(),
                 (bag.path / "data" / "data1").mkdir(),
@@ -602,12 +599,32 @@ def test_bag_validator_payload_files_required(src, dst, profile, callback, ok):
             ],
             True,
         ),
+        # Allow only additional data1 subtree
         (
-            {"Payload-Files-Allowed": ["data/*"]},
+            {"Payload-Files-Allowed": ["data/data1/*"]},
             lambda bag: [
-                (bag.path / "data" / "payload1.txt").touch(),
-                (bag.path / "data" / "data1").mkdir(),
-                (bag.path / "data" / "data1" / "payload2.txt").touch(),
+                (
+                    bag.path
+                    / "data"
+                    / "data1"
+                    / "data2"
+                ).mkdir(parents=True),
+                (
+                    bag.path
+                    / "data"
+                    / "data1"
+                    / "data2"
+                    / "payload.jpg"
+                ).touch(),
+            ],
+            True,
+        ),
+        # Reject file outside permitted directory trees
+        (
+            {"Payload-Files-Allowed": ["data/preservation_master/*"]},
+            lambda bag: [
+                (bag.path / "data" / "other").mkdir(),
+                (bag.path / "data" / "other" / "file.txt").touch(),
             ],
             False,
         ),
@@ -616,6 +633,12 @@ def test_bag_validator_payload_files_required(src, dst, profile, callback, ok):
 def test_bag_validator_payload_files_allowed(src, dst, profile, callback, ok):
     """Test validation for allowed payload-files."""
     bag: Bag = create_test_bag(src, dst)
+
+    # Ensure deterministic payload: remove copied payload from src
+    for path in bag.path.glob("data/**/*"):
+        if path.is_file():
+            path.unlink()
+
     callback(bag)
 
     assert (


### PR DESCRIPTION
Fixes #16 

# Summary

This PR fixes the handling of `Payload-Files-Allowed` patterns that end with `/*`. Per the BagIt Profile specification, a trailing `/*` indicates a permitted directory and its contents, including all files and subdirectories.

The previous implementation treated `*` as a non-recursive glob, which led to false negatives for valid Bags with nested payload structures.

# Changes

- Interpret `Payload-Files-Allowed` entries ending in `/*` as permitting directory trees
- Match directory patterns against ancestor directories of payload files
- Update tests to reflect the corrected semantics